### PR TITLE
[Fix] 캘린더 깜빡임, 복약 시간 텍스트 한글화, 통계 화면 드롭다운 수정 #8

### DIFF
--- a/app/src/main/java/com/konkuk/medicarecall/domain/model/type/HealthIssueType.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/domain/model/type/HealthIssueType.kt
@@ -3,7 +3,7 @@ package com.konkuk.medicarecall.domain.model.type
 enum class HealthIssueType(val displayName: String) {
     INSOMNIA("불면증 / 수면장애"),
     FORGETS_MEDICATION("약 자주 잊음"),
-    MOBILITY_ISSUE("보행 불편"),
+    WALKING_DIFFICULTY("보행 불편"),
     HEARING_LOSS("청력 저하"),
     COGNITIVE_DECLINE("인지저하 의심"),
     MOOD_SWINGS("감정기복"),

--- a/app/src/main/java/com/konkuk/medicarecall/domain/model/type/MedicationTime.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/domain/model/type/MedicationTime.kt
@@ -2,7 +2,7 @@ package com.konkuk.medicarecall.domain.model.type
 
 // 아침, 점심, 저녁 enum
 enum class MedicationTime(val displayName: String) {
-    BREAKFAST("아침"),
+    MORNING("아침"),
     LUNCH("점심"),
     DINNER("저녁"),
 }

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/MedInfoItem.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/MedInfoItem.kt
@@ -220,7 +220,7 @@ private fun MedInfoItemPreview() {
                 medications = mutableListOf(
                     MedicationSchedule(
                         medicationName = "당뇨약",
-                        scheduleTimes = listOf(MedicationTime.BREAKFAST, MedicationTime.DINNER),
+                        scheduleTimes = listOf(MedicationTime.MORNING, MedicationTime.DINNER),
                     ),
                 ),
             )

--- a/app/src/main/java/com/konkuk/medicarecall/ui/common/component/MedicationItem.kt
+++ b/app/src/main/java/com/konkuk/medicarecall/ui/common/component/MedicationItem.kt
@@ -153,7 +153,7 @@ private fun MedicationItemPreview() {
         Column(Modifier.padding(16.dp)) {
             MedicationItem(
                 medications = listOf(
-                    Medication("당뇨약", listOf(MedicationTime.BREAKFAST)),
+                    Medication("당뇨약", listOf(MedicationTime.MORNING)),
                     Medication("혈압약", listOf(MedicationTime.DINNER)),
                 ),
                 selectedTimes = listOf(),

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/mapper/HomeMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/mapper/HomeMapper.kt
@@ -37,9 +37,17 @@ private fun HomeResponseDto.MedicationDto.toMedicines(): Medicines {
         medicineName = type.orEmpty(),
         todayTakenCount = taken,
         todayRequiredCount = goal,
-        nextDoseTime = nextTime,
+        nextDoseTime = formatNextDoseTimeToKorean(nextTime),
         doseStatusList = doseStatusList?.map { it.toHomeDoseStatus() } ?: emptyList(),
     )
+}
+
+private fun formatNextDoseTimeToKorean(nextTime: String?): String? {
+    if (nextTime.isNullOrBlank()) return nextTime
+    return nextTime
+        .replace("MORNING", "아침약")
+        .replace("LUNCH", "점심약")
+        .replace("DINNER", "저녁약")
 }
 
 // Dose DTO → Domain

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/mapper/HomeMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/mapper/HomeMapper.kt
@@ -6,6 +6,7 @@ import com.konkuk.medicarecall.domain.model.Home
 import com.konkuk.medicarecall.domain.model.HomeDoseStatusList
 import com.konkuk.medicarecall.domain.model.HomeSleep
 import com.konkuk.medicarecall.domain.model.Medicines
+import com.konkuk.medicarecall.domain.model.type.MedicationTime
 import com.konkuk.medicarecall.ui.feature.home.viewmodel.DoseStatusUiState
 import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeUiState
 import com.konkuk.medicarecall.ui.feature.home.viewmodel.MedicineUiState
@@ -44,10 +45,7 @@ private fun HomeResponseDto.MedicationDto.toMedicines(): Medicines {
 
 private fun formatNextDoseTimeToKorean(nextTime: String?): String? {
     if (nextTime.isNullOrBlank()) return nextTime
-    return nextTime
-        .replace("MORNING", "아침약")
-        .replace("LUNCH", "점심약")
-        .replace("DINNER", "저녁약")
+    return MedicationTime.fromRaw(nextTime)?.toDoseLabel() ?: nextTime
 }
 
 // Dose DTO → Domain
@@ -188,12 +186,6 @@ object HomeMapper {
         }
     }
 
-    private fun getDefaultNextDose(firstTimeKey: Any?): String {
-        return when (firstTimeKey?.toString()?.uppercase()) {
-            "MORNING" -> "아침약"
-            "LUNCH" -> "점심약"
-            "DINNER" -> "저녁약"
-            else -> "-"
-        }
-    }
+    private fun getDefaultNextDose(firstTimeKey: Any?): String =
+        MedicationTime.fromRaw(firstTimeKey?.toString())?.toDoseLabel() ?: "-"
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/mapper/HomeMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/mapper/HomeMapper.kt
@@ -190,9 +190,9 @@ object HomeMapper {
 
     private fun getDefaultNextDose(firstTimeKey: Any?): String {
         return when (firstTimeKey?.toString()?.uppercase()) {
-            "MORNING" -> "아침"
-            "LUNCH" -> "점심"
-            "DINNER" -> "저녁"
+            "MORNING" -> "아침약"
+            "LUNCH" -> "점심약"
+            "DINNER" -> "저녁약"
             else -> "-"
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/model/ElderIds.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/model/ElderIds.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ElderIds(
     val elderIds: Map<Long, String>,
+    val selectedElderId: Long = -1L,
 )

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repository/ElderIdRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repository/ElderIdRepository.kt
@@ -3,6 +3,8 @@ package com.konkuk.medicarecall.data.repository
 interface ElderIdRepository {
     suspend fun updateElderIds(elderIdMap: Map<Long, String>)
     suspend fun updateElderId(elderId: Long, name: String)
+    suspend fun updateSelectedElderId(elderId: Long)
+    suspend fun getSelectedElderId(): Long
     suspend fun clearElderIds()
     suspend fun getElderIds(): Map<Long, String>
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/ElderIdRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/ElderIdRepositoryImpl.kt
@@ -21,6 +21,15 @@ class ElderIdRepositoryImpl(
         elderIdDataStore.updateData { it.copy(elderIds = it.elderIds.plus(elderId to name)) }
     }
 
+    override suspend fun updateSelectedElderId(elderId: Long) {
+        elderIdDataStore.updateData { it.copy(selectedElderId = elderId) }
+    }
+
+    override suspend fun getSelectedElderId(): Long {
+        val preferences = elderIdDataStore.data.first()
+        return preferences.selectedElderId
+    }
+
     override suspend fun getElderIds(): Map<Long, String> {
         val preferences = elderIdDataStore.data.map { it.elderIds }
         return preferences.first()
@@ -28,7 +37,7 @@ class ElderIdRepositoryImpl(
 
     override suspend fun clearElderIds() {
         elderIdDataStore.updateData {
-            ElderIds(elderIds = emptyMap())
+            ElderIds(elderIds = emptyMap(), selectedElderId = -1L)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/model/type/HealthIssueType.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/model/type/HealthIssueType.kt
@@ -3,7 +3,7 @@ package com.konkuk.medicarecall.domain.model.type
 enum class HealthIssueType(val displayName: String) {
     INSOMNIA("불면증 / 수면장애"),
     FORGETS_MEDICATION("약 자주 잊음"),
-    MOBILITY_ISSUE("보행 불편"),
+    WALKING_DIFFICULTY("보행 불편"),
     HEARING_LOSS("청력 저하"),
     COGNITIVE_DECLINE("인지저하 의심"),
     MOOD_SWINGS("감정기복"),

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/model/type/MedicationTime.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/model/type/MedicationTime.kt
@@ -2,7 +2,7 @@ package com.konkuk.medicarecall.domain.model.type
 
 // 아침, 점심, 저녁 enum
 enum class MedicationTime(val displayName: String) {
-    BREAKFAST("아침"),
+    MORNING("아침"),
     LUNCH("점심"),
     DINNER("저녁"),
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/model/type/MedicationTime.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/model/type/MedicationTime.kt
@@ -5,4 +5,18 @@ enum class MedicationTime(val displayName: String) {
     MORNING("아침"),
     LUNCH("점심"),
     DINNER("저녁"),
+    ;
+
+    fun toDoseLabel(): String = "${displayName}약"
+
+    companion object {
+        fun fromRaw(value: String?): MedicationTime? {
+            return when (value?.trim()?.uppercase()) {
+                "MORNING" -> MORNING
+                "LUNCH" -> LUNCH
+                "DINNER" -> DINNER
+                else -> null
+            }
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/common/component/MedInfoItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/common/component/MedInfoItem.kt
@@ -215,7 +215,7 @@ private fun MedInfoItemPreview() {
                 medications = mutableListOf(
                     MedicationSchedule(
                         medicationName = "당뇨약",
-                        scheduleTimes = listOf(MedicationTime.BREAKFAST, MedicationTime.DINNER),
+                        scheduleTimes = listOf(MedicationTime.MORNING, MedicationTime.DINNER),
                     ),
                 ),
             )

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/common/component/MedicationItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/common/component/MedicationItem.kt
@@ -151,7 +151,7 @@ private fun MedicationItemPreview() {
         Column(Modifier.padding(16.dp)) {
             MedicationItem(
                 medications = listOf(
-                    Medication("당뇨약", listOf(MedicationTime.BREAKFAST)),
+                    Medication("당뇨약", listOf(MedicationTime.MORNING)),
                     Medication("혈압약", listOf(MedicationTime.DINNER)),
                 ),
                 selectedTimes = listOf(),

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/home/navigation/HomeNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/home/navigation/HomeNavigation.kt
@@ -1,10 +1,13 @@
 package com.konkuk.medicarecall.ui.feature.home.navigation
 
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.konkuk.medicarecall.ui.feature.home.screen.HomeScreen
+import com.konkuk.medicarecall.ui.feature.home.viewmodel.HomeViewModel
 import com.konkuk.medicarecall.ui.navigation.MainTabRoute
 
 fun NavController.navigateToHome(navOptions: NavOptions) {
@@ -18,9 +21,11 @@ fun NavGraphBuilder.homeNavGraph(
     navigateToStateHealthDetailScreen: (Long) -> Unit,
     navigateToStateMentalDetailScreen: (Long) -> Unit,
     navigateToGlucoseDetailScreen: (Long) -> Unit,
+    getBackStackHomeViewModel: @Composable (NavBackStackEntry) -> HomeViewModel,
 ) {
     composable<MainTabRoute.Home> { backStackEntry ->
         HomeScreen(
+            viewModel = getBackStackHomeViewModel(backStackEntry),
             navigateToMealDetailScreen = { elderId ->
                 navigateToMealDetailScreen(elderId)
             },

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/home/viewmodel/HomeViewModel.kt
@@ -87,6 +87,7 @@ class HomeViewModel(
             _selectedElderId.collect { elderId ->
                 if (elderId != -1L) {
                     savedStateHandle[KEY_SELECTED_ELDER_ID] = elderId
+                    elderIdRepository.updateSelectedElderId(elderId)
                     fetchHomeSummaryForToday(elderId)
                 } else {
                     _homeUiState.value = HomeUiState.EMPTY.copy(isLoading = false)
@@ -120,8 +121,14 @@ class HomeViewModel(
             _elderInfoList.value = elderIdMap.map {
                 ElderInfo(elderId = it.key, name = it.value)
             }
+            val currentSelectedId = _selectedElderId.value
+            val sharedSelectedId = elderIdRepository.getSelectedElderId()
             val restoredId = savedStateHandle.get<Long>(KEY_SELECTED_ELDER_ID) ?: -1L
-            if (restoredId != -1L && _elderInfoList.value.any { it.elderId == restoredId }) {
+            if (currentSelectedId != -1L && _elderInfoList.value.any { it.elderId == currentSelectedId }) {
+                _selectedElderId.value = currentSelectedId
+            } else if (sharedSelectedId != -1L && _elderInfoList.value.any { it.elderId == sharedSelectedId }) {
+                _selectedElderId.value = sharedSelectedId
+            } else if (restoredId != -1L && _elderInfoList.value.any { it.elderId == restoredId }) {
                 _selectedElderId.value = restoredId
             } else if (_selectedElderId.value == -1L && _elderInfoList.value.isNotEmpty()) {
                 _selectedElderId.value = _elderInfoList.value.first().elderId
@@ -192,6 +199,7 @@ class HomeViewModel(
         val id = elderIdByName[name] ?: return
 
         if (_selectedElderId.value != id) {
+            savedStateHandle[KEY_SELECTED_ELDER_ID] = id
             _selectedElderId.value = id
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
@@ -14,6 +14,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -40,6 +43,7 @@ fun StateHealthDetailScreen(
     viewModel: HealthViewModel = koinViewModel(),
 ) {
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    var isInitialLoading by remember { mutableStateOf(true) }
 
     // 재진입 시 오늘로 초기화
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
@@ -54,17 +58,11 @@ fun StateHealthDetailScreen(
         viewModel.loadHealthDataForDate(elderId, selectedDate)
     }
 
-    if (!isLoading)
-        StateHealthDetailScreenLayout(
-            modifier = Modifier,
-            onBack = onBack,
-            selectedDate = selectedDate,
-            health = health,
-            weekDates = selectedDate.getCurrentWeekDates(),
-            onDateSelected = { viewModel.selectDate(it) },
-            onMonthClick = { /* 모달 열기 */ },
-        )
-    else
+    LaunchedEffect(isLoading) {
+        if (!isLoading) isInitialLoading = false
+    }
+
+    if (isLoading && isInitialLoading) {
         Box(
             Modifier
                 .fillMaxSize()
@@ -75,6 +73,17 @@ fun StateHealthDetailScreen(
                 color = MediCareCallTheme.colors.main,
             )
         }
+    } else {
+        StateHealthDetailScreenLayout(
+            modifier = Modifier,
+            onBack = onBack,
+            selectedDate = selectedDate,
+            health = health,
+            weekDates = selectedDate.getCurrentWeekDates(),
+            onDateSelected = { viewModel.selectDate(it) },
+            onMonthClick = { /* 모달 열기 */ },
+        )
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/homedetail/statehealth/screen/StateHealthDetailScreen.kt
@@ -43,7 +43,7 @@ fun StateHealthDetailScreen(
     viewModel: HealthViewModel = koinViewModel(),
 ) {
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
-    var isInitialLoading by remember { mutableStateOf(true) }
+    var isInitialLoading by remember(elderId) { mutableStateOf(true) }
 
     // 재진입 시 오늘로 초기화
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/StatisticsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/statistics/viewmodel/StatisticsViewModel.kt
@@ -40,11 +40,15 @@ class StatisticsViewModel(
 
     init {
         viewModelScope.launch {
+            _uiState.update { it.copy(eldersMap = eldersIdRepository.getElderIds()) }
+        }
+
+        viewModelScope.launch {
             _uiState
                 .map { it.selectedElderId to it.currentWeek }
                 .distinctUntilChanged()
                 .collect { (id, week) ->
-                    if (id != null) {
+                    if (id != -1L) {
                         // [수정 2] 주차가 변경될 때마다 isLatestWeek와 isEarliestWeek를 다시 계산합니다.
                         // 이렇게 하면 API 호출 성공/실패와 관계없이 UI 상태가 정확해집니다.
                         val weekStart = week.first
@@ -58,7 +62,6 @@ class StatisticsViewModel(
                         getWeeklyStatistics(elderId = id, startDate = weekStart)
                     }
                 }
-            _uiState.update { it.copy(eldersMap = eldersIdRepository.getElderIds()) }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/navigation/NavGraph.kt
@@ -75,6 +75,9 @@ fun NavGraph(
 //            )
 //        }
         homeNavGraph(
+            getBackStackHomeViewModel = { backStackEntry ->
+                backStackEntry.sharedViewModel<HomeViewModel, MainTabRoute.Home>(navController)
+            },
             navigateToMealDetailScreen = navigator::navigateToMealDetailScreen,
             navigateToMedicineDetailScreen = navigator::navigateToMedicineDetailScreen,
             navigateToSleepDetailScreen = navigator::navigateToSleepDetailScreen,


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #8 

## 📙 작업 설명
- 건강징후 상세화면에서 날짜 변경시 전체화면이 깜빡이던 현상 수정
- 복약시간 한글변환 함수 추가 → 홈화면의 복약시간이 한글로 표시되도록 수정
- 통계화면
  - 드롭다운시 어르신이름이 제대로 뜨도록 수정
  - 홈과 주간통계화면에서 어르신 변경시 화면전환시에도 선택상태가 정상반영되도록 수정 

## 📸 스크린샷 또는 시연 영상 (선택)

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 안드로이드에서도 정상반영이 됐는지 확인 부탁드립니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 선택한 보호자(어르신) ID가 앱에 저장되어 유지됩니다.

* **버그 수정**
  * 건강 데이터 화면의 초기 로딩 표시가 개선되어 초기 로드 중 전체화면 로딩을 보여줍니다.

* **개선 사항**
  * 약 복용 시간이 한국어(아침약/점심약/저녁약)로 더 명확히 표시됩니다.
  * 보호자 선택 로직과 상태 복원/동기화, Home 화면의 뷰모델 연결이 정비되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->