### PR TITLE
[Fix] 푸시 알림 설정 변경 사항 반영 안되는 거 수정(공통), 안드로이드 스타일 복구(폰트, 그림자)  #12

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.android.kt
@@ -1,60 +1,19 @@
 package com.konkuk.medicarecall.ui.theme
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.Dp
 
 actual fun Modifier.figmaShadow(
     group: ShadowGroup,
     cornerRadius: Dp,
-): Modifier = this.drawWithCache {
-    val radiusPx = cornerRadius.toPx()
-    val paint = Paint().asFrameworkPaint().apply {
-        isAntiAlias = true
-        color = 0
-    }
-
-    onDrawWithContent {
-        group.layers.forEach { layer ->
-            paint.setShadowLayer(
-                layer.blurRadius.toPx(),
-                layer.offsetX.toPx(),
-                layer.offsetY.toPx(),
-                layer.color.toArgb(),
-            )
-            drawIntoCanvas { canvas ->
-                val nc = canvas.nativeCanvas
-                nc.drawRoundRect(
-                    0f,
-                    0f,
-                    size.width,
-                    size.height,
-                    radiusPx,
-                    radiusPx,
-                    paint,
-                )
-            }
-        }
-
-        paint.clearShadowLayer()
-
-        drawIntoCanvas { canvas ->
-            val nc = canvas.nativeCanvas
-            nc.drawRoundRect(
-                0f,
-                0f,
-                size.width,
-                size.height,
-                radiusPx,
-                radiusPx,
-                paint,
-            )
-        }
-
-        drawContent()
-    }
+): Modifier = group.layers.fold(this) { acc, layer ->
+    acc.shadow(
+        elevation = layer.blurRadius,
+        shape = RoundedCornerShape(cornerRadius),
+        ambientColor = layer.color,
+        spotColor = layer.color,
+        clip = false
+    )
 }

--- a/composeApp/src/androidMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.android.kt
@@ -1,0 +1,60 @@
+package com.konkuk.medicarecall.ui.theme
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+
+actual fun Modifier.figmaShadow(
+    group: ShadowGroup,
+    cornerRadius: Dp,
+): Modifier = this.drawWithCache {
+    val radiusPx = cornerRadius.toPx()
+    val paint = Paint().asFrameworkPaint().apply {
+        isAntiAlias = true
+        color = 0
+    }
+
+    onDrawWithContent {
+        group.layers.forEach { layer ->
+            paint.setShadowLayer(
+                layer.blurRadius.toPx(),
+                layer.offsetX.toPx(),
+                layer.offsetY.toPx(),
+                layer.color.toArgb(),
+            )
+            drawIntoCanvas { canvas ->
+                val nc = canvas.nativeCanvas
+                nc.drawRoundRect(
+                    0f,
+                    0f,
+                    size.width,
+                    size.height,
+                    radiusPx,
+                    radiusPx,
+                    paint,
+                )
+            }
+        }
+
+        paint.clearShadowLayer()
+
+        drawIntoCanvas { canvas ->
+            val nc = canvas.nativeCanvas
+            nc.drawRoundRect(
+                0f,
+                0f,
+                size.width,
+                size.height,
+                radiusPx,
+                radiusPx,
+                paint,
+            )
+        }
+
+        drawContent()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/viewmodel/SettingsEditMyDataViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/viewmodel/SettingsEditMyDataViewModel.kt
@@ -3,6 +3,7 @@ package com.konkuk.medicarecall.ui.feature.settings.mydata.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.medicarecall.data.repository.UserRepository
+import com.konkuk.medicarecall.domain.model.PushNotification
 import com.konkuk.medicarecall.domain.model.UserInfo
 import com.konkuk.medicarecall.domain.model.type.GenderType
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,7 +57,12 @@ class SettingsEditMyDataViewModel(
             try {
                 userRepository.updateMyInfo(userInfo)
                     .onSuccess {
-                        _uiState.update { it.copy(isUpdateSuccess = true) }
+                        _uiState.update {
+                            it.copy(
+                                isUpdateSuccess = true,
+                                myDataInfo = userInfo, // 저장 성공 시 최신 데이터로 동기화
+                            )
+                        }
                         onComplete?.invoke()
                     }
                     .onFailure { e ->
@@ -72,11 +78,6 @@ class SettingsEditMyDataViewModel(
         }
     }
 
-    // 화면 진입 시나 필요 시 상태 초기화
-    fun resetStatus() {
-        _uiState.update { it.copy(isUpdateSuccess = false, errorMessage = null) }
-    }
-
     fun initializeNotificationSettings(myDataInfo: UserInfo) {
         val masterOn = myDataInfo.pushNotification.isAllEnabled
         _uiState.update {
@@ -89,42 +90,70 @@ class SettingsEditMyDataViewModel(
         }
     }
 
-    fun setMasterChecked(value: Boolean) {
-        _uiState.update {
-            it.copy(
-                masterChecked = value,
-                completeChecked = value,
-                abnormalChecked = value,
-                missedChecked = value,
-            )
-        }
-    }
+    // 토글 타입별로 새 상태를 계산하고 서버에 반영하는 함수
+    fun updateNotificationSettingByType(
+        type: String,
+        checked: Boolean,
+    ) {
+        val currentInfo = uiState.value.myDataInfo ?: return
+        val currentState = uiState.value
 
-    fun setCompleteChecked(value: Boolean) {
-        _uiState.update {
-            it.copy(
-                completeChecked = value,
-                masterChecked = if (!value) false else it.masterChecked,
-            )
-        }
-    }
+        val newMasterChecked: Boolean
+        val newCompleteChecked: Boolean
+        val newAbnormalChecked: Boolean
+        val newMissedChecked: Boolean
 
-    fun setAbnormalChecked(value: Boolean) {
-        _uiState.update {
-            it.copy(
-                abnormalChecked = value,
-                masterChecked = if (!value) false else it.masterChecked,
-            )
-        }
-    }
+        when (type) {
+            "master" -> {
+                newMasterChecked = checked
+                newCompleteChecked = checked
+                newAbnormalChecked = checked
+                newMissedChecked = checked
+            }
 
-    fun setMissedChecked(value: Boolean) {
+            "complete" -> {
+                newCompleteChecked = checked
+                newAbnormalChecked = currentState.abnormalChecked
+                newMissedChecked = currentState.missedChecked
+                newMasterChecked = checked && newAbnormalChecked && newMissedChecked
+            }
+
+            "abnormal" -> {
+                newCompleteChecked = currentState.completeChecked
+                newAbnormalChecked = checked
+                newMissedChecked = currentState.missedChecked
+                newMasterChecked = newCompleteChecked && checked && newMissedChecked
+            }
+
+            "missed" -> {
+                newCompleteChecked = currentState.completeChecked
+                newAbnormalChecked = currentState.abnormalChecked
+                newMissedChecked = checked
+                newMasterChecked = newCompleteChecked && newAbnormalChecked && checked
+            }
+
+            else -> return
+        }
+
         _uiState.update {
             it.copy(
-                missedChecked = value,
-                masterChecked = if (!value) false else it.masterChecked,
+                masterChecked = newMasterChecked,
+                completeChecked = newCompleteChecked,
+                abnormalChecked = newAbnormalChecked,
+                missedChecked = newMissedChecked,
             )
         }
+
+        val updatedUserInfo = currentInfo.copy(
+            pushNotification = PushNotification(
+                all = if (newMasterChecked) "ON" else "OFF",
+                carecallCompleted = if (newCompleteChecked) "ON" else "OFF",
+                healthAlert = if (newAbnormalChecked) "ON" else "OFF",
+                carecallMissed = if (newMissedChecked) "ON" else "OFF",
+            ),
+        )
+
+        updateUserData(updatedUserInfo)
     }
 
     fun initializeFormData(myDataInfo: UserInfo) {

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/notification/screen/SettingsNotificationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/notification/screen/SettingsNotificationScreen.kt
@@ -19,19 +19,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.konkuk.medicarecall.resources.Res
-import com.konkuk.medicarecall.resources.*
+import com.konkuk.medicarecall.resources.ic_settings_back
 import com.konkuk.medicarecall.ui.feature.settings.component.SettingsTopAppBar
-import com.konkuk.medicarecall.domain.model.PushNotification
-import com.konkuk.medicarecall.ui.feature.settings.notification.component.SwitchButton
 import com.konkuk.medicarecall.ui.feature.settings.mydata.viewmodel.SettingsEditMyDataViewModel
+import com.konkuk.medicarecall.ui.feature.settings.notification.component.SwitchButton
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
+import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -50,21 +49,7 @@ fun SettingsNotificationScreen(
         uiState.myDataInfo?.let { viewModel.initializeNotificationSettings(it) }
     }
 
-    val updateSettings = {
-        uiState.myDataInfo?.let { info ->
-            viewModel.updateUserData(
-                userInfo = info.copy(
-                    pushNotification = PushNotification(
-                        all = if (uiState.masterChecked) "ON" else "OFF",
-                        carecallCompleted = if (uiState.completeChecked) "ON" else "OFF",
-                        healthAlert = if (uiState.abnormalChecked) "ON" else "OFF",
-                        carecallMissed = if (uiState.missedChecked) "ON" else "OFF",
-                    ),
-                ),
-            )
-        }
-    }
-
+    // ViewModel 내부에서 새 체크 상태 기준으로 저장
     if (uiState.isLoading && uiState.myDataInfo == null) {
         Box(
             modifier = modifier
@@ -112,8 +97,10 @@ fun SettingsNotificationScreen(
                 SwitchButton(
                     checked = uiState.masterChecked,
                     onCheckedChange = { isChecked ->
-                        viewModel.setMasterChecked(isChecked)
-                        updateSettings()
+                        viewModel.updateNotificationSettingByType(
+                            type = "master",
+                            checked = isChecked,
+                        )
                     },
                 )
             }
@@ -130,8 +117,10 @@ fun SettingsNotificationScreen(
                 SwitchButton(
                     checked = uiState.completeChecked,
                     onCheckedChange = { isChecked ->
-                        viewModel.setCompleteChecked(isChecked)
-                        updateSettings()
+                        viewModel.updateNotificationSettingByType(
+                            type = "complete",
+                            checked = isChecked,
+                        )
                     },
                 )
             }
@@ -148,8 +137,10 @@ fun SettingsNotificationScreen(
                 SwitchButton(
                     checked = uiState.abnormalChecked,
                     onCheckedChange = { isChecked ->
-                        viewModel.setAbnormalChecked(isChecked)
-                        updateSettings()
+                        viewModel.updateNotificationSettingByType(
+                            type = "abnormal",
+                            checked = isChecked,
+                        )
                     },
                 )
             }
@@ -166,8 +157,10 @@ fun SettingsNotificationScreen(
                 SwitchButton(
                     checked = uiState.missedChecked,
                     onCheckedChange = { isChecked ->
-                        viewModel.setMissedChecked(isChecked)
-                        updateSettings()
+                        viewModel.updateNotificationSettingByType(
+                            type = "missed",
+                            checked = isChecked,
+                        )
                     },
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.kt
@@ -3,10 +3,6 @@ package com.konkuk.medicarecall.ui.theme
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -39,7 +35,6 @@ val defaultMediCareCallShadow = MediCareCallShadows(
             ShadowLayer(-4.dp, 0.dp, 8.dp, Color(0xFF222222).copy(alpha = 0.02f)),
         ),
     ),
-
     shadow02 = ShadowGroup(
         listOf(
             ShadowLayer(0.dp, 4.dp, 12.dp, Color(0xFF222222).copy(alpha = 0.04f)),
@@ -47,7 +42,6 @@ val defaultMediCareCallShadow = MediCareCallShadows(
             ShadowLayer(-4.dp, 0.dp, 12.dp, Color(0xFF222222).copy(alpha = 0.04f)),
         ),
     ),
-
     shadow03 = ShadowGroup(
         listOf(
             ShadowLayer(0.dp, 4.dp, 16.dp, Color(0xFF222222).copy(alpha = 0.04f)),
@@ -59,21 +53,7 @@ val defaultMediCareCallShadow = MediCareCallShadows(
 
 val LocalMediCareCallShadowProvider = staticCompositionLocalOf { defaultMediCareCallShadow }
 
-fun Modifier.figmaShadow(
+expect fun Modifier.figmaShadow(
     group: ShadowGroup,
     cornerRadius: Dp = 14.dp,
-): Modifier = this.drawWithCache {
-    val radiusPx = cornerRadius.toPx()
-
-    onDrawWithContent {
-        group.layers.forEach { layer ->
-            drawRoundRect(
-                color = layer.color,
-                topLeft = Offset(layer.offsetX.toPx(), layer.offsetY.toPx()),
-                size = Size(size.width, size.height),
-                cornerRadius = CornerRadius(radiusPx, radiusPx),
-            )
-        }
-        drawContent()
-    }
-}
+): Modifier

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/theme/Theme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import com.konkuk.medicarecall.platform.platformDynamicColorScheme
 
@@ -32,11 +33,21 @@ fun MediCareCallTheme(
         else -> LightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content,
-    )
+    val mediCareCallTypography = createMediCareCallTypography()
+    val mediCareCallColors = defaultMediCareCallColors
+    val mediCareCallShadow = defaultMediCareCallShadow
+
+    CompositionLocalProvider(
+        LocalMediCareCallColorsProvider provides mediCareCallColors,
+        LocalMedicareCallTypographyProvider provides mediCareCallTypography,
+        LocalMediCareCallShadowProvider provides mediCareCallShadow,
+    ) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content,
+        )
+    }
 }
 
 object MediCareCallTheme {

--- a/composeApp/src/iosMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/konkuk/medicarecall/ui/theme/Effect.ios.kt
@@ -1,0 +1,27 @@
+package com.konkuk.medicarecall.ui.theme
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.Dp
+
+actual fun Modifier.figmaShadow(
+    group: ShadowGroup,
+    cornerRadius: Dp,
+): Modifier = this.drawWithCache {
+    val radiusPx = cornerRadius.toPx()
+
+    onDrawWithContent {
+        group.layers.forEach { layer ->
+            drawRoundRect(
+                color = layer.color,
+                topLeft = Offset(layer.offsetX.toPx(), layer.offsetY.toPx()),
+                size = Size(size.width, size.height),
+                cornerRadius = CornerRadius(radiusPx, radiusPx),
+            )
+        }
+        drawContent()
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #12 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 설정화면의 푸시알림 설정과 관련해서 설정을 변경했을 때 해당 설정이 제대로 반영되지 않는 문제를 해결했습니다.
- 안드로이드앱에서 폰트, 그림자가 제대로 적용되지 않았던 문제를 해결했습니다.

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 안드로이드와 iOS에서 다층 그림자(Figma 스타일) 렌더링 지원 추가

* **개선 사항**
  * 공통 테마 접근 방식 개선으로 색상·타이포그래피·그림자 전역 접근성 향상
  * 알림 설정 인터랙션 개선: 토글 변경 시 관련 상태를 일괄 계산해 적용하고 서버 동기화 수행

* **기타**
  * 플랫폼별 그림자 구현을 분리해 멀티플랫폼 호환성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->