### PR TITLE
[Fix] 로그인 / 로그아웃 토큰 및 네비게이션 수정 #14

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/ApiModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/ApiModule.kt
@@ -50,7 +50,7 @@ class ApiModule {
         ktorfit.createRefreshService()
 
     @Single
-    fun authService(ktorfit: Ktorfit): AuthService =
+    fun authService(@AuthKtorfit ktorfit: Ktorfit): AuthService =
         ktorfit.createAuthService()
 
     @Single
@@ -58,7 +58,7 @@ class ApiModule {
         ktorfit.createEldersInfoService()
 
     @Single
-    fun memberRegisterService(ktorfit: Ktorfit): MemberRegisterService =
+    fun memberRegisterService(@AuthKtorfit ktorfit: Ktorfit): MemberRegisterService =
         ktorfit.createMemberRegisterService()
 
     @Single

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/NetworkModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/NetworkModule.kt
@@ -79,23 +79,28 @@ class NetworkModule {
 
                 refreshTokens {
                     refreshMutex.withLock {
-                        // 3. 현재 저장된 토큰들을 가져옴
-                        val accessToken = dataStoreRepository.getAccessToken()
                         val refreshToken = dataStoreRepository.getRefreshToken()
+                        if (refreshToken.isNullOrBlank()) {
+                            dataStoreRepository.saveRefreshToken("")
+                            return@withLock null
+                        }
 
-                        require(!refreshToken.isNullOrEmpty())
-                        val refreshResponse = refreshService.refreshToken(refreshToken)
+                        val refreshResponse = runCatching {
+                            refreshService.refreshToken(refreshToken)
+                        }.getOrElse {
+                            dataStoreRepository.saveRefreshToken("")
+                            return@withLock null
+                        }
 
                         if (refreshResponse.isSuccessful && refreshResponse.body() != null) {
-                            // 토큰 갱신 성공 시, 새로운 토큰들을 DataStore에 저장
                             val newTokens = refreshResponse.body()!!
                             dataStoreRepository.saveAccessToken(newTokens.accessToken)
                             dataStoreRepository.saveRefreshToken(newTokens.refreshToken)
 
-                            val newAccessToken = dataStoreRepository.getAccessToken()
-                            val newRefreshToken = dataStoreRepository.getRefreshToken()
-
-                            BearerTokens(newAccessToken ?: "", newRefreshToken)
+                            BearerTokens(
+                                accessToken = newTokens.accessToken,
+                                refreshToken = newTokens.refreshToken,
+                            )
                         } else {
                             // 토큰 갱신 실패 시, 저장된 토큰 삭제 후 null 반환
                             dataStoreRepository.saveRefreshToken("")

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/UserRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.konkuk.medicarecall.data.api.auth.AuthService
 import com.konkuk.medicarecall.data.api.member.SettingService
 import com.konkuk.medicarecall.data.mapper.UserMapper
 import com.konkuk.medicarecall.data.repository.DataStoreRepository
+import com.konkuk.medicarecall.data.repository.ElderIdRepository
 import com.konkuk.medicarecall.data.repository.UserRepository
 import com.konkuk.medicarecall.data.util.handleNullableResponse
 import com.konkuk.medicarecall.data.util.handleResponse
@@ -15,6 +16,7 @@ class UserRepositoryImpl(
     private val settingService: SettingService,
     private val authService: AuthService,
     private val tokenStore: DataStoreRepository,
+    private val elderIdRepository: ElderIdRepository,
 ) : UserRepository {
     override suspend fun getMyInfo() = runCatching {
         val responseDto = settingService.getMyInfo().handleResponse()
@@ -27,10 +29,18 @@ class UserRepositoryImpl(
         UserMapper.toDomain(responseDto)
     }
 
-    override suspend fun logout(): Result<Unit> = runCatching {
-        val refresh = tokenStore.getRefreshToken() ?: error("Refresh token is null")
-        authService.logout("Bearer $refresh").handleNullableResponse()
         // 성공/실패와 무관하게 로컬 토큰 제거(보안/UX 측면에서 권장)
+    override suspend fun logout(): Result<Unit> {
+        runCatching {
+            val refresh = tokenStore.getRefreshToken()
+            if (!refresh.isNullOrBlank()) {
+                authService.logout("Bearer $refresh").handleNullableResponse()
+            }
+        }
+
         tokenStore.clearTokens()
+        elderIdRepository.clearElderIds()
+
+        return Result.success(Unit)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/usecase/CheckLoginStatusUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/domain/usecase/CheckLoginStatusUseCase.kt
@@ -2,6 +2,7 @@ package com.konkuk.medicarecall.domain.usecase
 
 import com.konkuk.medicarecall.data.repository.ElderIdRepository
 import com.konkuk.medicarecall.data.repository.EldersInfoRepository
+import com.konkuk.medicarecall.data.repository.DataStoreRepository
 import com.konkuk.medicarecall.ui.model.NavigationDestination
 import org.koin.core.annotation.Factory
 import com.konkuk.medicarecall.data.exception.HttpException
@@ -10,6 +11,7 @@ import com.konkuk.medicarecall.data.exception.HttpException
 class CheckLoginStatusUseCase(
     private val eldersInfoRepository: EldersInfoRepository,
     private val elderIdRepository: ElderIdRepository,
+    private val dataStoreRepository: DataStoreRepository,
 ) {
     /**
      * 앱의 초기 상태를 확인하여 다음에 이동할 화면을 결정합니다.
@@ -17,6 +19,13 @@ class CheckLoginStatusUseCase(
      */
     suspend operator fun invoke(): NavigationDestination {
         return runCatching {
+            val accessToken = dataStoreRepository.getAccessToken()
+            val refreshToken = dataStoreRepository.getRefreshToken()
+
+            if (accessToken.isNullOrBlank() || refreshToken.isNullOrBlank()) {
+                return@runCatching NavigationDestination.GoToLogin
+            }
+
             // 1. 어르신 정보 확인
             val elders = eldersInfoRepository.getElders().getOrThrow()
 

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/navigation/MainNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/navigation/MainNavigator.kt
@@ -193,9 +193,8 @@ class MainNavigator(
 
     fun navigateToLoginAfterLogout() {
         navController.navigate(Route.LoginStart) {
-            popUpTo(MainTabRoute.Home) { inclusive = true }
+            popUpTo(0) { inclusive = true }
             launchSingleTop = true
-            restoreState = true
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #14 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 로그인 
로그인 전 요청에서 auth refresh 로직이 개입하며 illegal requirement 예외가 발생
  - AuthService, MemberRegisterService가 auth bearer client 대신 비인증 @AuthKtorfit를 사용하도록 변경
  - NetworkModule의 refresh 로직에서 require(!refreshToken.isNullOrEmpty()) 제거
  - refresh token이 없거나 refresh 호출 중 예외가 발생하면 null 반환으로 실패 처리
  - 재발급 성공 시 DataStore 재조회 대신 응답 토큰으로 바로 BearerTokens 구성

- 로그아웃
로그아웃 이후에도 로컬 세션 상태가 남아 있어 시작하기 -> Home으로 바로 이동하는 문제
  - 로그아웃 시 서버 logout API 실패 여부와 무관하게 로컬 세션 정리
  - 로그아웃 시 저장된 토큰뿐 아니라 로컬 어르신 ID 캐시도 함께 삭제
  - 로그아웃 후 로그인 시작 화면으로 이동할 때 이전 메인 화면 상태가 복원되지 않도록 네비게이션 초기화
  - 로그인 시작 화면의 시작하기 동작은 기존 의도대로 checkStatus()를 통해 로그인 상태에 따라 분기하도록 유지

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 토큰 새로고침 실패 시 토큰을 안전하게 제거하고 재시도 중단하도록 안정성 강화
  - 로그아웃 흐름에서 토큰과 연관된 모든 로컬 데이터(연령자 ID 등)를 확실히 정리하도록 개선
  - 로그아웃 후 네비게이션 동작을 수정해 백스택 처리를 간소화

- **개선**
  - 인증 관련 서비스 연결을 더 견고하게 처리하도록 조정
  - 로그인 상태 확인 시 토큰 유무를 우선 검사하여 불필요한 호출 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->