### PR TITLE
[Feat] 회원탈퇴 기능 구현 #16

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/api/member/MemberDeleteService.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/api/member/MemberDeleteService.kt
@@ -4,6 +4,6 @@ import de.jensklingenberg.ktorfit.Response
 import de.jensklingenberg.ktorfit.http.DELETE
 
 interface MemberDeleteService {
-    @DELETE("member}")
+    @DELETE("member")
     suspend fun deleteMember(): Response<Unit>
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/api/member/MemberDeleteService.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/api/member/MemberDeleteService.kt
@@ -1,0 +1,9 @@
+package com.konkuk.medicarecall.data.api.member
+
+import de.jensklingenberg.ktorfit.Response
+import de.jensklingenberg.ktorfit.http.DELETE
+
+interface MemberDeleteService {
+    @DELETE("member}")
+    suspend fun deleteMember(): Response<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/ApiModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/ApiModule.kt
@@ -32,8 +32,10 @@ import com.konkuk.medicarecall.data.api.fcm.FcmUpdateService
 import com.konkuk.medicarecall.data.api.fcm.FcmValidationService
 import com.konkuk.medicarecall.data.api.fcm.createFcmUpdateService
 import com.konkuk.medicarecall.data.api.fcm.createFcmValidationService
+import com.konkuk.medicarecall.data.api.member.MemberDeleteService
 import com.konkuk.medicarecall.data.api.member.MemberRegisterService
 import com.konkuk.medicarecall.data.api.member.SettingService
+import com.konkuk.medicarecall.data.api.member.createMemberDeleteService
 import com.konkuk.medicarecall.data.api.member.createMemberRegisterService
 import com.konkuk.medicarecall.data.api.member.createSettingService
 import com.konkuk.medicarecall.data.api.notice.NoticeService
@@ -120,4 +122,8 @@ class ApiModule {
     @Single
     fun provideFcmUpdateService(ktorfit: Ktorfit): FcmUpdateService =
         ktorfit.createFcmUpdateService()
+
+    @Single
+    fun provideMemberDeleteService(ktorfit: Ktorfit): MemberDeleteService =
+        ktorfit.createMemberDeleteService()
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repository/MemberDeleteRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repository/MemberDeleteRepository.kt
@@ -1,0 +1,5 @@
+package com.konkuk.medicarecall.data.repository
+
+interface MemberDeleteRepository {
+    suspend fun deleteMember(): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/MemberDeleteRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/MemberDeleteRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.konkuk.medicarecall.data.repositoryimpl
+
+import com.konkuk.medicarecall.data.api.member.MemberDeleteService
+import com.konkuk.medicarecall.data.repository.MemberDeleteRepository
+import org.koin.core.annotation.Single
+
+@Single
+class MemberDeleteRepositoryImpl(
+    private val memberDeleteService: MemberDeleteService,
+) : MemberDeleteRepository {
+    override suspend fun deleteMember(): Result<Unit> = runCatching {
+        memberDeleteService.deleteMember()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/MemberDeleteRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/MemberDeleteRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.konkuk.medicarecall.data.repositoryimpl
 
 import com.konkuk.medicarecall.data.api.member.MemberDeleteService
 import com.konkuk.medicarecall.data.repository.MemberDeleteRepository
+import com.konkuk.medicarecall.data.util.handleNullableResponse
 import org.koin.core.annotation.Single
 
 @Single
@@ -9,6 +10,6 @@ class MemberDeleteRepositoryImpl(
     private val memberDeleteService: MemberDeleteService,
 ) : MemberDeleteRepository {
     override suspend fun deleteMember(): Result<Unit> = runCatching {
-        memberDeleteService.deleteMember()
+        memberDeleteService.deleteMember().handleNullableResponse()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/screen/SettingsMyDataScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/screen/SettingsMyDataScreen.kt
@@ -77,7 +77,21 @@ fun SettingsMyDataScreen(
         onBackClick = onBack,
         onEditClick = navigateToUserInfoSetting,
         onLogoutClick = { showLogoutDialog = true },
-        onServiceWithdrawClick = { viewModel.deleteUser() },
+        onServiceWithdrawClick = {
+            viewModel.deleteUser(
+                onSuccess = {
+                    viewModel.logout(
+                        onSuccess = {
+                            showLogoutDialog = false
+                            navigateToLoginAfterLogout()
+                        },
+                        onError = { error ->
+                        },
+                    )
+                },
+                onError = {},
+            )
+        },
         onLogoutDismiss = { showLogoutDialog = false },
         onLogoutConfirm = {
             viewModel.logout(

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/screen/SettingsMyDataScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/screen/SettingsMyDataScreen.kt
@@ -27,23 +27,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.konkuk.medicarecall.domain.model.type.GenderType
 import com.konkuk.medicarecall.resources.Res
-import com.konkuk.medicarecall.resources.*
 import com.konkuk.medicarecall.resources.ic_settings_back
 import com.konkuk.medicarecall.ui.common.util.formatDateToKorean
-import com.konkuk.medicarecall.ui.feature.settings.mydata.component.LogoutConfirmDialog
 import com.konkuk.medicarecall.ui.feature.settings.component.SettingInfoItem
 import com.konkuk.medicarecall.ui.feature.settings.component.SettingsTopAppBar
+import com.konkuk.medicarecall.ui.feature.settings.mydata.component.LogoutConfirmDialog
 import com.konkuk.medicarecall.ui.feature.settings.mydata.viewmodel.SettingsMyDataViewModel
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
 import com.konkuk.medicarecall.ui.theme.figmaShadow
-import com.konkuk.medicarecall.domain.model.type.GenderType
+import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -78,7 +77,7 @@ fun SettingsMyDataScreen(
         onBackClick = onBack,
         onEditClick = navigateToUserInfoSetting,
         onLogoutClick = { showLogoutDialog = true },
-        onServiceWithdrawClick = {},
+        onServiceWithdrawClick = { viewModel.deleteUser() },
         onLogoutDismiss = { showLogoutDialog = false },
         onLogoutConfirm = {
             viewModel.logout(

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/viewmodel/SettingsMyDataViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/viewmodel/SettingsMyDataViewModel.kt
@@ -48,12 +48,11 @@ class SettingsMyDataViewModel(
         }
     }
 
-    fun deleteUser() {
+    fun deleteUser(onSuccess: () -> Unit, onError: (Throwable) -> Unit) {
         viewModelScope.launch {
             memberDeleteRepository.deleteMember()
-                .onSuccess {
-                    userRepository.logout()
-                }
+                .onSuccess { onSuccess() }
+                .onFailure { onError(it) }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/viewmodel/SettingsMyDataViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/mydata/viewmodel/SettingsMyDataViewModel.kt
@@ -2,6 +2,7 @@ package com.konkuk.medicarecall.ui.feature.settings.mydata.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.konkuk.medicarecall.data.repository.MemberDeleteRepository
 import com.konkuk.medicarecall.data.repository.UserRepository
 import com.konkuk.medicarecall.domain.model.UserInfo
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,6 +14,7 @@ import org.koin.android.annotation.KoinViewModel
 @KoinViewModel
 class SettingsMyDataViewModel(
     private val userRepository: UserRepository,
+    private val memberDeleteRepository: MemberDeleteRepository,
 ) : ViewModel() {
     fun refresh() = getUserData()
 
@@ -42,6 +44,15 @@ class SettingsMyDataViewModel(
                 }
                 .onFailure {
                     it.printStackTrace()
+                }
+        }
+    }
+
+    fun deleteUser() {
+        viewModelScope.launch {
+            memberDeleteRepository.deleteMember()
+                .onSuccess {
+                    userRepository.logout()
                 }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/subscription/screen/SettingsSubscriptionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/settings/subscription/screen/SettingsSubscriptionScreen.kt
@@ -22,7 +22,6 @@ import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.konkuk.medicarecall.resources.Res
-import com.konkuk.medicarecall.resources.*
 import com.konkuk.medicarecall.resources.ic_settings_back
 import com.konkuk.medicarecall.ui.feature.settings.component.SettingsTopAppBar
 import com.konkuk.medicarecall.ui.feature.settings.subscription.component.SubscribeCard


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #16 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 회원 탈퇴 API를 연동하였습니다.
- 회원 탈퇴 이후 로그아웃되도록 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정의 '내 정보'에서 계정 삭제 기능이 추가되었으며, 삭제 성공 시 자동으로 로그아웃되어 로그인 화면으로 이동합니다.
  * 계정 삭제 요청이 비동기적으로 처리되어 실패/성공 콜백을 받을 수 있습니다.

* **리팩토링**
  * 내부 의존성 등록 및 리소스 import 정리를 통해 구현 구조를 정돈했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->