### PR TITLE
Feat: 알림 조회 API 연동

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/api/fcm/NotificationService.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/api/fcm/NotificationService.kt
@@ -1,8 +1,10 @@
 package com.konkuk.medicarecall.data.api.fcm
 
 import com.konkuk.medicarecall.data.dto.request.NotificationStatusRequestDto
+import com.konkuk.medicarecall.data.dto.response.NotificationPageResponseDto
 import de.jensklingenberg.ktorfit.Response
 import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.Path
 
@@ -12,4 +14,7 @@ interface NotificationService { // 알림 관련
         @Path("notificationId") notificationId: String,
         @Body status: NotificationStatusRequestDto,
     ): Response<Unit>
+
+    @GET("notifications")
+    suspend fun getNotifications(): Response<List<NotificationPageResponseDto>>
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/ApiModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/di/ApiModule.kt
@@ -30,8 +30,10 @@ import com.konkuk.medicarecall.data.api.elders.createStatisticsService
 import com.konkuk.medicarecall.data.api.elders.createSubscribeService
 import com.konkuk.medicarecall.data.api.fcm.FcmUpdateService
 import com.konkuk.medicarecall.data.api.fcm.FcmValidationService
+import com.konkuk.medicarecall.data.api.fcm.NotificationService
 import com.konkuk.medicarecall.data.api.fcm.createFcmUpdateService
 import com.konkuk.medicarecall.data.api.fcm.createFcmValidationService
+import com.konkuk.medicarecall.data.api.fcm.createNotificationService
 import com.konkuk.medicarecall.data.api.member.MemberRegisterService
 import com.konkuk.medicarecall.data.api.member.SettingService
 import com.konkuk.medicarecall.data.api.member.createMemberRegisterService
@@ -120,4 +122,8 @@ class ApiModule {
     @Single
     fun provideFcmUpdateService(ktorfit: Ktorfit): FcmUpdateService =
         ktorfit.createFcmUpdateService()
+
+    @Single
+    fun provideNotificationService(ktorfit: Ktorfit): NotificationService =
+        ktorfit.createNotificationService()
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/dto/response/NotificationPageResponseDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/dto/response/NotificationPageResponseDto.kt
@@ -1,0 +1,11 @@
+package com.konkuk.medicarecall.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationPageResponseDto(
+    val totalPages: Int,
+    val currentPageNumber: Int,
+    val currentElements: Int,
+    val notifications: List<NotificationResponseDto>,
+)

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/dto/response/NotificationResponseDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/dto/response/NotificationResponseDto.kt
@@ -1,0 +1,12 @@
+package com.konkuk.medicarecall.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationResponseDto(
+    val id: Int,
+    val title: String,
+    val body: String,
+    val isRead: Boolean,
+    val createdAt: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repository/NotificationRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repository/NotificationRepository.kt
@@ -1,6 +1,9 @@
 package com.konkuk.medicarecall.data.repository
 
+import com.konkuk.medicarecall.data.dto.response.NotificationPageResponseDto
+
 interface NotificationRepository {
     suspend fun changeNotificationState(id: String): Result<Unit>
     suspend fun testNotification(): Result<Unit>
+    suspend fun getNotifications(): Result<List<NotificationPageResponseDto>>
 }

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/NotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/data/repositoryimpl/NotificationRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.konkuk.medicarecall.data.repositoryimpl
+
+import com.konkuk.medicarecall.data.api.fcm.NotificationService
+import com.konkuk.medicarecall.data.dto.response.NotificationPageResponseDto
+import com.konkuk.medicarecall.data.repository.NotificationRepository
+import com.konkuk.medicarecall.data.util.handleResponse
+import org.koin.core.annotation.Single
+
+@Single
+class NotificationRepositoryImpl(
+    private val notificationService: NotificationService,
+) : NotificationRepository {
+    override suspend fun changeNotificationState(id: String): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun testNotification(): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getNotifications():
+        Result<List<NotificationPageResponseDto>> = runCatching {
+        notificationService.getNotifications().handleResponse()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/alarm/screen/AlarmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/alarm/screen/AlarmScreen.kt
@@ -6,23 +6,33 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.konkuk.medicarecall.domain.model.type.AlarmType
 import com.konkuk.medicarecall.resources.Res
-import com.konkuk.medicarecall.resources.*
+import com.konkuk.medicarecall.resources.ic_settings_back
 import com.konkuk.medicarecall.ui.feature.alarm.component.AlarmItem
+import com.konkuk.medicarecall.ui.feature.alarm.viewmodel.AlarmViewModel
 import com.konkuk.medicarecall.ui.feature.settings.component.SettingsTopAppBar
 import com.konkuk.medicarecall.ui.theme.MediCareCallTheme
-import com.konkuk.medicarecall.domain.model.type.AlarmType
+import org.jetbrains.compose.resources.painterResource
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AlarmScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: AlarmViewModel = koinViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val scrollState = rememberScrollState()
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -42,31 +52,53 @@ fun AlarmScreen(
                 )
             },
         )
-        AlarmItem(
-            AlarmType.NEW_ALARM,
-            "✅ 1차 케어콜이 완료되었어요. 확인해 보세요!",
-            "7월 8일 13:15",
-        )
-        AlarmItem(
-            AlarmType.READ_ALARM,
-            "❗ 박막례 어르신 건강이상 징후가 탐지되었어요. 확인해 주세요!",
-            "7월 7일 13:15",
-        )
-        AlarmItem(
-            AlarmType.READ_ALARM,
-            "📞 김옥자 어르신 케어콜 부재중 상태입니다. 확인해 주세요!",
-            "7월 7일 13:15",
-        )
-        AlarmItem(
-            AlarmType.READ_ALARM,
-            "❗ 박막례 어르신 건강이상 징후가 탐지되었어요. 확인해 주세요!",
-            "7월 7일 13:15",
-        )
-        AlarmItem(
-            AlarmType.READ_ALARM,
-            "✅ 1차 케어콜이 완료되었어요. 확인해 보세요!",
-            "7월 7일 13:15",
-        )
+        Column(
+            modifier = modifier.verticalScroll(scrollState),
+        ) {
+            if (uiState.errorMessage != null) {
+                AlarmItem(
+                    AlarmType.READ_ALARM,
+                    "공지사항 오류 발생",
+                    uiState.errorMessage ?: "",
+                )
+            } else {
+                uiState.alarmPages.forEach { alarmPage ->
+                    alarmPage.notifications.forEach { alarm ->
+                        AlarmItem(
+                            alarmType = if (alarm.isRead) AlarmType.READ_ALARM else AlarmType.NEW_ALARM,
+                            content = alarm.body,
+                            date = alarm.createdAt.replace("-", "."),
+                        )
+                    }
+                }
+
+            }
+        }
+//        AlarmItem(
+//            AlarmType.NEW_ALARM,
+//            "✅ 1차 케어콜이 완료되었어요. 확인해 보세요!",
+//            "7월 8일 13:15",
+//        )
+//        AlarmItem(
+//            AlarmType.READ_ALARM,
+//            "❗ 박막례 어르신 건강이상 징후가 탐지되었어요. 확인해 주세요!",
+//            "7월 7일 13:15",
+//        )
+//        AlarmItem(
+//            AlarmType.READ_ALARM,
+//            "📞 김옥자 어르신 케어콜 부재중 상태입니다. 확인해 주세요!",
+//            "7월 7일 13:15",
+//        )
+//        AlarmItem(
+//            AlarmType.READ_ALARM,
+//            "❗ 박막례 어르신 건강이상 징후가 탐지되었어요. 확인해 주세요!",
+//            "7월 7일 13:15",
+//        )
+//        AlarmItem(
+//            AlarmType.READ_ALARM,
+//            "✅ 1차 케어콜이 완료되었어요. 확인해 보세요!",
+//            "7월 7일 13:15",
+//        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/alarm/viewmodel/AlarmUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/alarm/viewmodel/AlarmUiState.kt
@@ -1,0 +1,8 @@
+package com.konkuk.medicarecall.ui.feature.alarm.viewmodel
+
+import com.konkuk.medicarecall.data.dto.response.NotificationPageResponseDto
+
+data class AlarmUiState(
+    val alarmPages: List<NotificationPageResponseDto> = emptyList(),
+    val errorMessage: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/alarm/viewmodel/AlarmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/konkuk/medicarecall/ui/feature/alarm/viewmodel/AlarmViewModel.kt
@@ -1,0 +1,35 @@
+package com.konkuk.medicarecall.ui.feature.alarm.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.konkuk.medicarecall.data.repository.NotificationRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.android.annotation.KoinViewModel
+
+@KoinViewModel
+class AlarmViewModel(
+    private val repository: NotificationRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(AlarmUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        loadAlarms()
+    }
+
+    private fun loadAlarms() {
+        viewModelScope.launch {
+            repository.getNotifications()
+                .onSuccess { alarmPages ->
+                    _uiState.update { it.copy(alarmPages = alarmPages) }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(errorMessage = "알림을 불러오지 못했습니다.") }
+                    it.printStackTrace()
+                }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #17 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 알림 조회 화면에서 뜰 알림들 목록을 서버로부터 받아와 알림 조회 화면에 뜨도록 합니다.

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 서버로부터 알림들을 받아올 때 페이지별로 알림을 40개씩 받아오는데, 모든 페이지를 한 번에 보내주는지, 한 페이지만 보내주는 지 명시가 안돼 있어서 일단 모든 페이지를 받아온다는 가정하에 코드를 작성했습니다. (만약 특정 페이지 번호를 post로 보내서 받아오는 형태면 한페이지만 받아온다는 가정하에 작성을 할텐데 어떤 페이지의 알림들을 받아오는지 서버에 보내는 부분이 없더라고요)
- 이는 추후에 서버한테 한 번 물어보고 수정이 필요할 경우 수정하도록 하겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 화면에서 서버로부터 실시간 알림 목록을 조회하는 기능 추가
  * 알림의 제목, 내용, 읽음 상태, 생성 날짜 정보 표시
  * 페이지네이션을 지원하여 대량의 알림을 효율적으로 로드
  * 알림 조회 실패 시 사용자에게 오류 메시지 안내

<!-- end of auto-generated comment: release notes by coderabbit.ai -->